### PR TITLE
null Membership policy

### DIFF
--- a/About-null-community/null-membership.md
+++ b/About-null-community/null-membership.md
@@ -1,0 +1,45 @@
+## Overview
+
+null is a member-led organization. Members serve as Leaders, and volunteers for our community. Members have a vote in the election of null Leadership. Membership is a privilege guided by the [Code of Conduct](https://github.com/null-open-security-community/Documentation/CODE_OF_CONDUCT.md), which has dues set by the null Leadership, and are detailed below.
+
+## Membership
+
+Membership is explicitly defined as people that pay dues. Nearly all null activities are open to both members and nonmembers. Some example activities include participating in a Project or Chapter, attending chapter meetings, joining mailing lists or attending events. Merely participating in the activities of the null organization does not make that person a Member; membership includes only those who pay dues to the null organization.
+
+Individual Members can check their Membership Status, renewal dates, and update their billing information by sending an email to [membership-support@null.community](mailto:membership-support@null.community).
+
+Members in “good standing” are defined as those who have paid dues appropriate with their membership level while also not subject to any disciplinary action(s) by the null organization.
+
+While the null organization will make diligent efforts to inform members of their membership - in particular expiration dates - it is the sole responsibility of the member to manage their membership and renewals.
+
+## Individual Membership Benefits
+
+-   Ongoing support of our mission
+
+-   Vote in null elections
+
+-   Complimentary null.community email address
+
+-   Access to Membership benefits offered by our partners
+
+-   Participation in null special interest groups (IoT, Cloud, Fuzzing, Crypto, OSINT, etc.)
+
+-   Participation in null projects (Any ongoing projects null is working on based on your interest)
+
+-   Participation in null event organization and management
+
+## Becoming an Individual Member
+
+Individuals can only become members of the null organization by completing the [Membership Form](https://forms.gle/FZ25rMFvRFTuBYUcA) and paying dues, and complying with the following conditions:
+
+-   The Applicant agree to the [Code of Conduct](https://github.com/null-open-security-community/Documentation/CODE_OF_CONDUCT.md)
+
+-   Membership dues are paid by the Applicant.
+
+-   Applicant must complete and successfully submit the membership form.
+
+-   Applicant consents to receive communications from null concerning membership status.
+
+-   Once paid, Membership Dues are not prorated, nor can they be canceled once purchased.
+
+null will revoke fraudulent membership submissions without notice and no refund. Memberships and member benefits are not transferrable.

--- a/About-null-community/null-membership.md
+++ b/About-null-community/null-membership.md
@@ -30,9 +30,9 @@ While the null organization will make diligent efforts to inform members of thei
 
 ## Becoming an Individual Member
 
-Individuals can only become members of the null organization by completing the [Membership Form](https://forms.gle/FZ25rMFvRFTuBYUcA) and paying dues, and complying with the following conditions:
+Individuals can only become members of the null organization by completing the [Membership Form](https://null.community/membership-application) and paying dues, and complying with the following conditions:
 
--   The Applicant agree to the [Code of Conduct](https://github.com/null-open-security-community/Documentation/CODE_OF_CONDUCT.md)
+-   The Applicant agrees to the [Code of Conduct](https://github.com/null-open-security-community/Documentation/CODE_OF_CONDUCT.md)
 
 -   Membership dues are paid by the Applicant.
 


### PR DESCRIPTION
Here are the assumptions made in the document:

1. Code of conduct is available (https://github.com/null-open-security-community/Documentation/pull/5 needs to merge)
2. Members can reach out to membership-support@null.community for help
3. Embed the google form ,[https://forms.gle/FZ25rMFvRFTuBYUcA](https://forms.gle/FZ25rMFvRFTuBYUcA), inside a new null.community page such as [https://null.community/membership-application](https://null.community/membership-application) or a redirect the link to the form so that we don't create any hard dependencies on google forms. 